### PR TITLE
DUA experimentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@ static/
 core/ld-config.json
 celerybeat-schedule
 
+tmp/
+
 # IDE configurations
 .idea
+.vscode

--- a/claimant/src/components/ClaimFormNav/ClaimFormNav.tsx
+++ b/claimant/src/components/ClaimFormNav/ClaimFormNav.tsx
@@ -162,7 +162,7 @@ export const ClaimFormNav = ({ isSubmitted }: ClaimFormNavProps) => {
     <div className="usa-nav-container">
       <div className="usa-navbar">
         <Title>
-          <Link to={HOME_PAGE}>Unemployment Insurance</Link>
+          <Link to={HOME_PAGE}>Disaster Unemployment Assistance</Link>
         </Title>
         <NavMenuButton
           label="Menu"

--- a/claimant/src/i18n/en/common.ts
+++ b/claimant/src/i18n/en/common.ts
@@ -62,6 +62,7 @@ const common = {
     education_vocational_rehab: "Education and training",
     recent_employer: "Add employer",
     employer_review: "Your recent work history",
+    dua_self_employment: "(DUA) Self-employment",
     self_employment: "Self-employment",
     other_pay: "Other pay",
     occupation: "Occupation information",

--- a/claimant/src/pages/PageDefinitions.tsx
+++ b/claimant/src/pages/PageDefinitions.tsx
@@ -8,7 +8,8 @@ import { OccupationPage } from "./Questions/Occupation/Occupation";
 import { UnionPage } from "./Questions/Union/Union";
 import { ReviewPage } from "./Questions/Review/Review";
 import { FC } from "react";
-import { SelfEmploymentPage } from "./Questions/SelfEmployment/SelfEmployment";
+import { DUASelfEmploymentPage } from "./Questions/DUASelfEmployment/DUASelfEmployment";
+// import { SelfEmploymentPage } from "./Questions/SelfEmployment/SelfEmployment";
 import { EducationVocationalRehabPage } from "./Questions/EducationVocationalRehab/EducationVocationalRehab";
 import { DisabilityStatusPage } from "./Questions/DisabilityStatus/DisabilityStatus";
 import { ContactInformationPage } from "./Questions/ContactInformation/ContactInformation";
@@ -48,9 +49,10 @@ export const pages: ReadonlyArray<IPageDefinition> = [
   ContactInformationPage,
   DemographicPage,
   IdentityPage,
+  DUASelfEmploymentPage,
   EmployerInformationPage,
   EmployerReviewPage,
-  SelfEmploymentPage,
+  // SelfEmploymentPage,
   OtherPayInformationPage,
   OccupationPage,
   EducationVocationalRehabPage,

--- a/claimant/src/pages/Questions/DUASelfEmployment/DUASelfEmployment.tsx
+++ b/claimant/src/pages/Questions/DUASelfEmployment/DUASelfEmployment.tsx
@@ -1,0 +1,65 @@
+// import { Fieldset } from "@trussworks/react-uswds";
+import { useFormikContext } from "formik";
+// import TextField from "../../../components/form/fields/TextField/TextField";
+import { IPageDefinition } from "../../PageDefinitions";
+// import { useClearFields } from "../../../hooks/useClearFields";
+import { YesNoQuestion } from "../../../components/form/YesNoQuestion/YesNoQuestion";
+// import HelpText from "../../../components/HelpText/HelpText";
+import * as yup from "yup";
+import { DateInputField } from "../../../components/form/fields/DateInputField/DateInputField";
+import TextAreaField from "../../../components/form/fields/TextAreaField/TextAreaField";
+
+export const DUASelfEmployment = () => {
+  const {
+    values: { dua_self_employment },
+  } = useFormikContext<ClaimantInput>();
+
+  const data: ClaimantInput["dua_self_employment"] = dua_self_employment || {};
+
+  return (
+    <>
+      <>
+        <YesNoQuestion
+          question={"At the time of the Disaster, were you self-employed?"}
+          name="dua_self_employment.was_self_employed"
+        />
+        {data.was_self_employed === false && (
+          <YesNoQuestion
+            question={
+              "Were you scheduled to begin self-employment work in the near future?"
+            }
+            name="dua_self_employment.scheduled_to_start_in_future"
+          />
+        )}
+        {data.scheduled_to_start_in_future && (
+          <>
+            <DateInputField
+              legend={
+                "When did you anticipate beginning self-employment work, if not for the disaster?"
+              }
+              name="dua_self_employment.date_scheduled_to_start_in_future"
+            />
+            <TextAreaField
+              name="dua_self_employment.reason_scheduled_to_start_in_future"
+              label="Why were you unable to begin on that date? "
+            />
+            <TextAreaField
+              name="dua_self_employment.steps_taken_prior_to_disaster"
+              label="What steps have you taken to begin self-employment prior to the Disaster?"
+            />
+          </>
+        )}
+      </>
+    </>
+  );
+};
+
+const pageSchema = () => yup.object();
+
+export const DUASelfEmploymentPage: IPageDefinition = {
+  path: "self-employment",
+  heading: "dua_self_employment",
+  initialValues: {},
+  Component: DUASelfEmployment,
+  pageSchema,
+};

--- a/claimant/src/types.d.ts
+++ b/claimant/src/types.d.ts
@@ -9,6 +9,7 @@ type ClaimantInput = {
   PaymentInformationType &
   EmployersType &
   SelfEmploymentType &
+  DUASelfEmploymentType &
   OtherPayType &
   DisabilityStatusType &
   AvailabilityType &
@@ -266,6 +267,13 @@ type SelfEmploymentType = DeepPartial<{
     name_of_corporation: string | null;
     related_to_owner: boolean;
     corporation_or_partnership: boolean;
+  };
+}>;
+
+type DUASelfEmploymentType = DeepPartial<{
+  dua_self_employment: {
+    was_self_employed: boolean;
+    scheduled_to_start_in_future: boolean;
   };
 }>;
 


### PR DESCRIPTION
# ETA ARPA UIP-000

[Acceptance flow diagram](https://github.com/USDepartmentofLabor/ui-claimant-experience-pilot/blob/main/docs/development-acceptance-flow.drawio.svg)

<!--
    If applicable, insert the Jira story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic (autolink references)
--->

## Changes proposed in this pull request

- Change 1
- Change 2

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer Notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## [Code Review](https://github.com/USDepartmentofLabor/ui-claimant-experience-pilot/blob/main/docs/team-norms.md#reviewing-prs) Verification Steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- User-facing changes ([detailed instructions)](https://github.com/USDepartmentofLabor/ui-claimant-experience-pilot/blob/main/docs/a11y-testing-instructions.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)
- [ ] Requested a design review for user-facing changes
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
- User-facing changes ([detailed instructions)](https://github.com/USDepartmentofLabor/ui-claimant-experience-pilot/blob/main/docs/a11y-testing-instructions.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a designer reviewer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow
- a11y checks ([detailed instructions)](https://github.com/USDepartmentofLabor/ui-claimant-experience-pilot/blob/main/docs/a11y-testing-instructions.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
